### PR TITLE
feat: qualify table name identifiers in dumper/loader 

### DIFF
--- a/internal/codegen/golang/dumploader.go
+++ b/internal/codegen/golang/dumploader.go
@@ -68,11 +68,11 @@ func (d DumpLoader) ParamList() string {
 }
 
 func (d DumpLoader) DumpSQL() string {
-	return fmt.Sprintf("SELECT %s FROM %s ORDER BY %s ASC;",
+	return fmt.Sprintf(`SELECT %s FROM \"%s\" ORDER BY %s ASC;`,
 		d.FieldDBNames(), d.MainStruct.Table.Name, d.DumpSortByFields())
 }
 
 func (d DumpLoader) LoadSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s);",
+	return fmt.Sprintf(`INSERT INTO \"%s\" (%s) VALUES (%s);`,
 		d.MainStruct.Table.Name, d.FieldDBNames(), d.ParamList())
 }


### PR DESCRIPTION
Table name such as "user" is reserved in postgres. When using this kind of words for tablename, we need to qualify it using double quotes in queries

Executing following statement will run into error showing that the table schema is not correctly set:
<img width="292" alt="image" src="https://github.com/Stumble/sqlc/assets/12558511/d5852a6a-80b6-45aa-bcb3-6716e387369d">
 
``` SQL
SELECT "id",
       signin_type,
       signin_provider,
       signin_value,
       info,
       created_at,
       updated_at,
       referrer_id
FROM user
ORDER BY id, signin_value, created_at, updated_at, referrer_id ASC;
```

The fix is simply quotes the tablename `FROM user` -> `FROM "user"`. And the statement will run.