### PR TITLE
fix data race in wpgx invalidate generation

### DIFF
--- a/internal/codegen/golang/templates/wpgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/wpgx/queryCode.tmpl
@@ -99,11 +99,11 @@ func _{{.MethodName}}(ctx context.Context, q {{.ConnType}}, {{.Arg.Pair}} {{.Inv
         if {{.ArgName}} != nil {
         {{ end -}}
             key := {{.CacheKey}}
-            err = q.GetCache().Invalidate(ctx, key)
-            if err != nil {
-                log.Ctx(ctx).Error().Err(err).Msgf(
+            invalidateErr := q.GetCache().Invalidate(ctx, key)
+            if invalidateErr != nil {
+                log.Ctx(ctx).Error().Err(invalidateErr).Msgf(
                     "Failed to invalidate: %s", key)
-                anyErr <- err
+                anyErr <- invalidateErr
             }
         {{ if not .NoArg -}}
         }
@@ -203,11 +203,11 @@ func _{{.MethodName}}(ctx context.Context, q {{.ConnType}}, {{.Arg.Pair}} {{.Inv
         if {{.ArgName}} != nil {
         {{ end -}}
             key := {{.CacheKey}}
-            err = q.GetCache().Invalidate(ctx, key)
-            if err != nil {
-                log.Ctx(ctx).Error().Err(err).Msgf(
+            invalidateErr := q.GetCache().Invalidate(ctx, key)
+            if invalidateErr != nil {
+                log.Ctx(ctx).Error().Err(invalidateErr).Msgf(
                     "Failed to invalidate: %s", key)
-                anyErr <- err
+                anyErr <- invalidateErr
             }
         {{ if not .NoArg -}}
         }
@@ -248,11 +248,11 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
         if {{.ArgName}} != nil {
         {{ end -}}
             key := {{.CacheKey}}
-            err = q.cache.Invalidate(ctx, key)
-            if err != nil {
-                log.Ctx(ctx).Error().Err(err).Msgf(
+            invalidateErr := q.cache.Invalidate(ctx, key)
+            if invalidateErr != nil {
+                log.Ctx(ctx).Error().Err(invalidateErr).Msgf(
                     "Failed to invalidate: %s", key)
-                anyErr <- err
+                anyErr <- invalidateErr
             }
         {{ if not .NoArg -}}
         }
@@ -293,11 +293,11 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
         if {{.ArgName}} != nil {
         {{ end -}}
             key := {{.CacheKey}}
-            err = q.cache.Invalidate(ctx, key)
-            if err != nil {
-                log.Ctx(ctx).Error().Err(err).Msgf(
+            invalidateErr := q.cache.Invalidate(ctx, key)
+            if invalidateErr != nil {
+                log.Ctx(ctx).Error().Err(invalidateErr).Msgf(
                     "Failed to invalidate: %s", key)
-                anyErr <- err
+                anyErr <- invalidateErr
             }
         {{ if not .NoArg -}}
         }
@@ -338,11 +338,11 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
         if {{.ArgName}} != nil {
         {{ end -}}
             key := {{.CacheKey}}
-            err = q.cache.Invalidate(ctx, key)
-            if err != nil {
-                log.Ctx(ctx).Error().Err(err).Msgf(
+            invalidateErr := q.cache.Invalidate(ctx, key)
+            if invalidateErr != nil {
+                log.Ctx(ctx).Error().Err(invalidateErr).Msgf(
                     "Failed to invalidate: %s", key)
-                anyErr <- err
+                anyErr <- invalidateErr
             }
         {{ if not .NoArg -}}
         }


### PR DESCRIPTION
## Summary
This fixes a race in generated wpgx invalidate blocks when a query has multiple `invalidate` targets.

The template currently writes to the outer `err` variable from multiple goroutines (`err = q.GetCache().Invalidate(...)`), which trips the race detector in generated repositories.

This change switches those writes to a goroutine-local variable (`invalidateErr`) in all invalidate code paths (`:one`, `:many`, `:exec`, `:execrows`, `:execresult`).

## Validation
- `go test ./internal/codegen/golang/...`
