### PR TITLE
Guard nil cache in wpgx invalidation hooks

### DIFF
--- a/internal/codegen/golang/templates/wpgx/queryCode.tmpl
+++ b/internal/codegen/golang/templates/wpgx/queryCode.tmpl
@@ -89,6 +89,9 @@ func _{{.MethodName}}(ctx context.Context, q {{.ConnType}}, {{.Arg.Pair}} {{.Inv
 {{ if  .Option.Invalidates -}}
     // invalidate
     _ = q.GetConn().PostExec(func() error {
+        if q.GetCache() == nil {
+            return nil
+        }
 		anyErr := make(chan error, {{len .Invalidates}})
 		var wg sync.WaitGroup
         wg.Add({{len .Invalidates}})
@@ -193,6 +196,9 @@ func _{{.MethodName}}(ctx context.Context, q {{.ConnType}}, {{.Arg.Pair}} {{.Inv
 {{ if  .Option.Invalidates -}}
     // invalidate
     _ = q.GetConn().PostExec(func() error {
+        if q.GetCache() == nil {
+            return nil
+        }
 		anyErr := make(chan error, {{len .Invalidates}})
 		var wg sync.WaitGroup
         wg.Add({{len .Invalidates}})
@@ -238,6 +244,9 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
 {{ if  .Option.Invalidates -}}
     // invalidate
     _ = q.db.PostExec(func() error {
+        if q.cache == nil {
+            return nil
+        }
 		anyErr := make(chan error, {{len .Invalidates}})
 		var wg sync.WaitGroup
         wg.Add({{len .Invalidates}})
@@ -283,6 +292,9 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
 {{ if  .Option.Invalidates -}}
     // invalidate
     _ = q.db.PostExec(func() error {
+        if q.cache == nil {
+            return nil
+        }
 		anyErr := make(chan error, {{len .Invalidates}})
 		var wg sync.WaitGroup
         wg.Add({{len .Invalidates}})
@@ -328,6 +340,9 @@ func (q *Queries) {{.MethodName}}(ctx context.Context, {{.Arg.Pair}} {{.Invalida
 {{ if  .Option.Invalidates -}}
     // invalidate
     _ = q.db.PostExec(func() error {
+        if q.cache == nil {
+            return nil
+        }
 		anyErr := make(chan error, {{len .Invalidates}})
 		var wg sync.WaitGroup
         wg.Add({{len .Invalidates}})


### PR DESCRIPTION
This change adds nil-cache guards before invalidation work runs in the wpgx query template. It prevents nil pointer issues when cache invalidation is configured but no cache instance is attached. The full workspace diff is limited to internal/codegen/golang/templates/wpgx/queryCode.tmpl with these guard checks added in each invalidation path.